### PR TITLE
JPA 설정 및 BaseEntity 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("io.spring.dependency-management") version "1.1.6"
     kotlin("jvm") version "2.0.20"
     kotlin("plugin.spring") version "2.0.20"
+    kotlin("plugin.jpa") version "2.0.20"
 }
 
 group = "com.cnap"
@@ -24,6 +25,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
     // Kotlin
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/src/main/kotlin/com/cnap/server/config/JpaConfig.kt
+++ b/src/main/kotlin/com/cnap/server/config/JpaConfig.kt
@@ -1,0 +1,8 @@
+package com.cnap.server.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@Configuration
+@EnableJpaAuditing
+class JpaConfig

--- a/src/main/kotlin/com/cnap/server/model/entity/BaseEntity.kt
+++ b/src/main/kotlin/com/cnap/server/model/entity/BaseEntity.kt
@@ -1,0 +1,21 @@
+package com.cnap.server.model.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@EntityListeners(AuditingEntityListener::class)
+@MappedSuperclass
+abstract class BaseEntity(
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    var createdAt: LocalDateTime? = null,
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    var updatedAt: LocalDateTime? = null
+)


### PR DESCRIPTION
## 관련 이슈
Closes #8

## 변경 사항

### JPA 설정
- kotlin-jpa plugin 추가
- spring-boot-starter-data-jpa 의존성
- BaseEntity (createdAt, updatedAt)
- JpaConfig (@EnableJpaAuditing)

## 커밋
- a1c2fc6 - add JPA auditing configuration and BaseEntity for audit fields

## 테스트
```bash
./gradlew build
# BaseEntity 상속 확인
```