### PR TITLE
CORS 및 OpenAPI/Swagger 문서화

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,9 @@ dependencies {
     // Logging
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
 
+    // OpenAPI (Swagger)
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
+
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.projectreactor:reactor-test")

--- a/src/main/kotlin/com/cnap/server/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/cnap/server/config/OpenApiConfig.kt
@@ -1,0 +1,40 @@
+package com.cnap.server.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.servers.Server
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfig {
+
+    @Bean
+    fun customOpenAPI(): OpenAPI {
+        return OpenAPI()
+            .info(
+                Info()
+                    .title("CNAP Server API")
+                    .version("0.0.1-SNAPSHOT")
+                    .description("Cloud Native Agent Platform Server API Documentation")
+            )
+            .servers(
+                listOf(
+                    Server().url("http://localhost:8080").description("Local Development Server")
+                )
+            )
+            .components(
+                Components()
+                    .addSecuritySchemes(
+                        "bearerAuth",
+                        SecurityScheme()
+                            .type(SecurityScheme.Type.HTTP)
+                            .scheme("bearer")
+                            .bearerFormat("JWT")
+                            .description("Bearer Token authentication")
+                    )
+            )
+    }
+}

--- a/src/main/kotlin/com/cnap/server/config/WebConfig.kt
+++ b/src/main/kotlin/com/cnap/server/config/WebConfig.kt
@@ -1,0 +1,27 @@
+package com.cnap.server.config
+
+import com.cnap.server.config.properties.CorsProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+@EnableConfigurationProperties(CorsProperties::class)
+class WebConfig {
+
+    @Bean
+    fun webMvcConfigurer(corsProperties: CorsProperties): WebMvcConfigurer {
+        return object : WebMvcConfigurer {
+            override fun addCorsMappings(registry: CorsRegistry) {
+                registry.addMapping("/**")
+                    .allowedOrigins(*corsProperties.allowedOrigins.toTypedArray())
+                    .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                    .allowedHeaders(*corsProperties.allowedHeaders.toTypedArray())
+                    .allowCredentials(corsProperties.allowCredentials)
+                    .maxAge(corsProperties.maxAge)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/cnap/server/config/properties/CorsProperties.kt
+++ b/src/main/kotlin/com/cnap/server/config/properties/CorsProperties.kt
@@ -1,0 +1,11 @@
+package com.cnap.server.config.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "cnap.cors")
+data class CorsProperties(
+    val allowedOrigins: List<String>,
+    val allowedHeaders: List<String>,
+    val allowCredentials: Boolean,
+    val maxAge: Long
+)

--- a/src/main/kotlin/com/cnap/server/controller/HealthController.kt
+++ b/src/main/kotlin/com/cnap/server/controller/HealthController.kt
@@ -1,12 +1,15 @@
 package com.cnap.server.controller
 
 import com.cnap.server.model.dto.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Profile
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Health", description = "Health check and version information APIs")
 @RestController
 @Profile("local")
 class HealthController {
@@ -17,6 +20,10 @@ class HealthController {
     @Value("\${cnap.kubernetes.namespace}")
     private lateinit var namespace: String
 
+    @Operation(
+        summary = "Health Check",
+        description = "Returns the current health status of the application"
+    )
     @GetMapping("/healthz")
     fun health(): ResponseEntity<ApiResponse<Map<String, Any>>> {
         val healthData = mapOf(
@@ -28,6 +35,10 @@ class HealthController {
         return ResponseEntity.ok(ApiResponse(result = healthData))
     }
 
+    @Operation(
+        summary = "Version Information",
+        description = "Returns version and build information of the application"
+    )
     @GetMapping("/version")
     fun version(): ResponseEntity<ApiResponse<Map<String, Any>>> {
         val versionData = mapOf(

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -29,6 +29,14 @@ cnap:
     allow-credentials: false
     max-age: 3600
 
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+
 logging:
   level:
     root: DEBUG

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -21,6 +21,13 @@ cnap:
     mode: ${CNAP_STREAM_MODE:sse}
   auth:
     token: ${CNAP_AUTH_TOKEN:local-dev-token}
+  cors:
+    allowed-origins:
+      - "*"
+    allowed-headers:
+      - "*"
+    allow-credentials: false
+    max-age: 3600
 
 logging:
   level:


### PR DESCRIPTION
## 관련 이슈
Closes #9

## 변경 사항

### CORS 설정
- CorsProperties (@ConfigurationProperties)
- WebConfig (하드코딩된 HTTP 메서드)
- application-local.yml CORS 설정

### OpenAPI/Swagger
- springdoc-openapi 2.7.0
- OpenApiConfig (JWT Bearer 인증 스키마)
- HealthController 어노테이션 (@Tag, @Operation)

## 커밋
- 18f3623 - configure CORS with customizable properties
- 924539a - integrate OpenAPI support with Swagger-UI

## 테스트
```bash
# Swagger UI
open http://localhost:8080/swagger-ui/index.html

# CORS 테스트
curl -X OPTIONS http://localhost:8080/healthz \
  -H "Origin: http://localhost:3000" -v
```