### PR TITLE
데이터베이스 환경 설정 (H2/MySQL)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,10 @@ dependencies {
     // Kubernetes Client
     implementation("io.fabric8:kubernetes-client:6.10.0")
 
+    // Database
+    runtimeOnly("com.h2database:h2:2.3.232")
+    runtimeOnly("com.mysql:mysql-connector-j:9.1.0")
+
     // Logging
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
 

--- a/src/main/kotlin/com/cnap/server/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/cnap/server/config/security/SecurityConfig.kt
@@ -31,10 +31,12 @@ class SecurityConfig(
                     "/version",
                     "/api-docs/**",
                     "/swagger-ui/**",
-                    "/swagger-ui.html"
+                    "/swagger-ui.html",
+                    "/h2-console/**"
                 ).permitAll()
                 .anyRequest().permitAll()
             }
+            .headers { it.frameOptions { frameOptions -> frameOptions.sameOrigin() } }
             .exceptionHandling { it.authenticationEntryPoint(jwtAuthenticationEntryPoint) }
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,61 @@
+spring:
+  application:
+    name: cnap-server-dev
+  datasource:
+    url: ${DB_URL}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    hikari:
+      max-lifetime: 175000
+      maximum-pool-size: 10
+      minimum-idle: 5
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+        dialect: org.hibernate.dialect.MySQLDialect
+
+server:
+  port: ${SERVER_PORT:8080}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+
+cnap:
+  kubernetes:
+    namespace: ${CNAP_K8S_NAMESPACE}
+  stream:
+    mode: ${CNAP_STREAM_MODE}
+  auth:
+    token: ${CNAP_AUTH_TOKEN}
+  jwt:
+    secret: ${CNAP_JWT_SECRET}
+    access-token-expiration: ${CNAP_JWT_ACCESS_TOKEN_EXPIRATION:1800000}
+    refresh-token-expiration: ${CNAP_JWT_REFRESH_TOKEN_EXPIRATION:2592000000}
+  cors:
+    allowed-origins:
+      - ${CNAP_CORS_ALLOWED_ORIGINS}
+    allowed-headers:
+      - "*"
+    allow-credentials: true
+    max-age: 3600
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+
+logging:
+  level:
+    root: INFO
+    com.cnap: INFO

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,6 +1,22 @@
 spring:
   application:
     name: cnap-server-local
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
 
 server:
   port: 8080


### PR DESCRIPTION
## 관련 이슈
Closes #8

## 변경 사항

### 데이터베이스 환경 설정
- application-local.yml: H2 in-memory (MySQL 호환 모드)
- application-dev.yml: MySQL (환경변수 사용)
- HikariCP 커넥션 풀 설정
- SecurityConfig: H2 콘솔 접근 허용, Frame options

## 커밋
- e1f3baa - add environment-specific configurations
- 00f56ed - add development environment configuration file

## 테스트
```bash
# Local (H2)
./gradlew bootRun --args='--spring.profiles.active=local'
open http://localhost:8080/h2-console

# Dev (MySQL)
export DB_HOST=localhost DB_PORT=3306 DB_NAME=cnap
./gradlew bootRun --args='--spring.profiles.active=dev'
```